### PR TITLE
Add the context menu to the input

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,14 @@ const BrowserWindow = electron.BrowserWindow;
 const path = require('path');
 const url = require('url');
 
+require('electron-context-menu')({
+  prepend: (params) => [{
+    label: 'Rainbow',
+    // only show it when right-clicking images
+    visible: params.mediaType === 'image'
+  }]
+});
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-runtime": "^6.23.0",
     "babelify": "^7.3.0",
     "browserify": "^14.1.0",
+    "electron-context-menu": "^0.8.0",
     "phantom": "^4.0.0",
     "phantomjs-prebuilt": "^2.1.14",
     "react": "^15.4.2",


### PR DESCRIPTION
Add a useful context menu to the text area.
Note: The `Inspect Element` option only it's display in development mode

<img width="568" alt="screen shot 2017-03-13 at 4 53 21 pm" src="https://cloud.githubusercontent.com/assets/11366687/23878545/9904140a-080d-11e7-8013-45b63b21dd27.png">
